### PR TITLE
Refactor entity architecture with EntityDescription pattern and entity migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/kclif9/hassactronneo)
 ![GitHub](https://img.shields.io/github/license/kclif9/hassactronneo)
 
-This is a custom integration for Home Assistant to integrate the Actron Air ecosystem. This integration currently supports the Actron Air Neo, but is targeted to support other systems in future. Let me know if you're keen to help test other Actron Air products.
+This is a custom integration for Home Assistant to integrate the Actron Air ecosystem. This integration currently supports both Actron Air Neo and Actron Air Que.
 
-This integration is currently the test version of the integration being submitted to Home Assistant for adding to the core integrations.
+This integration is currently the test version of the integration being submitted to Home Assistant for adding to the core integrations. When HA core is at feature parity, this HACS integration will be retired.
 
 ## Installation
 
@@ -35,66 +35,98 @@ This integration is currently the test version of the integration being submitte
 
 ## Configuration
 
-### Configuration Parameters
-
-The integration requires the following information during setup:
-
-- **Username**: Your Actron Air account username (email address)
-- **Password**: Your Actron Air account password
-
 ### Setup Process
+
+The integration uses an **OAuth2 Device Code** flow for authentication:
 
 1. In the Home Assistant UI, navigate to `Configuration` > `Devices & Services`.
 2. Click the `+ Add Integration` button.
 3. Search for `Actron Air` and select it.
-4. When prompted with the oAuth link, click it and login to your Actron Air account.
-5. The integration will connect to your Actron Air account and discover all your connected devices.
+4. A link and authorization code will be displayed. Open the link and authorize on the Actron Air website.
+5. Once authorized, the integration will automatically complete setup and discover all your connected devices.
 
 ### Configuration Notes
 
 - Each air conditioning unit under your account will be added as a separate device.
+- Reauthentication is supported if your token expires — Home Assistant will prompt you to re-authorize.
+- The integration can also be discovered automatically via DHCP for Neo devices.
 
 ## Features
 
-- **Climate Control**: Control your Actron Air air conditioning units.
-- **Sensors**: Monitor various sensors such as temperature, humidity, and system status.
-- **Switches**: Control switches for continuous fan and zone control.
+- **Climate Control**: Full control of your AC system and individual zones
+- **Sensors**: Compressor diagnostics, outdoor temperature, and wireless peripheral readings
+- **Binary Sensors**: Filter cleaning alerts and defrost mode status
+- **Switches**: Away mode, continuous fan, quiet mode, and turbo mode
+- **Covers**: Read-only zone damper position monitoring
+- **Diagnostics**: Full system and status data export with sensitive fields redacted
 
 ## Supported Devices
 
 This integration supports the following Actron Air devices:
 
 - **Actron Air Neo Series**: All models of the Neo Series air conditioners
+- **Actron Air Que Series**: Que Series air conditioners
 - **Zone Controllers**: Control individual zones within your system
 - **Wall Controllers**: Compatible with wall controller units
-- **Temperature/Humidity Sensors**: Compatible with remote temperature sensors
+- **Wireless Peripherals**: Temperature, humidity, and battery sensors
 
-The integration does not currently support older Actron Air models, or those that are not part of the Neo ecosystem. We are keen to support other systems in future. Let me know if you're keen to help test other Actron Air products.
+The integration does not currently support older Actron Air models, or those that are not part of the Neo/Que ecosystem. We are keen to support other systems in future. Let me know if you're keen to help test other Actron Air products.
 
-## Supported Functions
+## Entities
 
-The integration supports the following functions:
+### Climate
 
-### Climate Controls
-- Turn the air conditioning system on/off
-- Change operating mode (Cool, Heat, Fan, Auto)
-- Set target temperature
-- Change fan speed (Auto, Low, Medium, High)
-- Enable/disable continuous fan operation
-
-### Zone Controls
-- Turn individual zones on/off
-- Set zone-specific temperatures
-- Monitor zone temperature and humidity
+| Entity | Features | Notes |
+|---|---|---|
+| AC System | Target temperature, fan mode, HVAC mode, on/off | HVAC modes: Cool, Heat, Fan, Auto, Dry. Fan modes: Auto, Low, Medium, High. Exposes current temperature and humidity. |
+| Zone (per zone) | Target temperature, on/off | One entity per configured zone. Exposes current temperature and humidity. No independent fan mode. |
 
 ### Sensors
-- System temperature sensors
-- Zone temperature sensors
-- System humidity sensors
-- Zone humidity sensors
-- Battery levels for wireless components
-- System status indicators
-- Fan speed indicators
+
+**System-level** (on the AC device):
+
+| Sensor | Device Class | Unit | Enabled by Default |
+|---|---|---|---|
+| Outdoor temperature | Temperature | °C | Yes |
+| Compressor mode | — | — | No |
+| Compressor chasing temperature | Temperature | °C | No |
+| Compressor live temperature | Temperature | °C | No |
+| Compressor power | Power | W | No |
+| Compressor speed | — | — | No |
+| Compressor capacity | — | % | No |
+| Fan speed | — | RPM | No |
+
+**Wireless peripherals** (per sensor device):
+
+| Sensor | Device Class | Unit |
+|---|---|---|
+| Temperature | Temperature | °C |
+| Humidity | Humidity | % |
+| Battery | Battery | % |
+
+### Binary Sensors
+
+| Sensor | Device Class | Category |
+|---|---|---|
+| Clean filter | Problem | Diagnostic |
+| Defrost mode | Running | Diagnostic |
+
+### Switches
+
+All switches are configuration entities.
+
+| Switch | Condition |
+|---|---|
+| Away mode | Always available |
+| Continuous fan | Always available |
+| Quiet mode | Always available |
+| Turbo mode | Only if supported by hardware |
+
+### Covers
+
+| Entity | Device Class | Notes |
+|---|---|---|
+| Zone damper position | Damper | Read-only. One per zone. Reports current position and open/closed state. |
 
 ## Data Updates
 
@@ -185,6 +217,7 @@ If you encounter issues, please check the Home Assistant logs for any error mess
 ### Common Issues
 
 #### Authentication Errors
+
 - **Symptom**: Unable to authenticate, entities show as unavailable
 - **Possible Causes**:
   - Incorrect username or password
@@ -196,6 +229,7 @@ If you encounter issues, please check the Home Assistant logs for any error mess
   - Wait a few minutes if you suspect a rate limit or lockout
 
 #### Connection Errors
+
 - **Symptom**: Entities unavailable, cannot control system
 - **Possible Causes**:
   - Actron Air cloud service is down
@@ -207,6 +241,7 @@ If you encounter issues, please check the Home Assistant logs for any error mess
   - Check if the official Actron Air app can connect to your system
 
 #### Zone Control Issues
+
 - **Symptom**: Cannot control individual zones
 - **Possible Causes**:
   - Zone controller is offline
@@ -217,6 +252,7 @@ If you encounter issues, please check the Home Assistant logs for any error mess
   - Check that zone controllers have power
 
 #### API Errors
+
 - **Symptom**: Errors in logs mentioning API issues, "too many requests", or timeouts
 - **Possible Causes**:
   - Rate limiting by the Actron Air cloud service
@@ -227,6 +263,7 @@ If you encounter issues, please check the Home Assistant logs for any error mess
   - Check the GitHub repository for known issues
 
 #### System Functionality Limitations
+
 - **Symptom**: Cannot access certain features available in the official app
 - **Solution**: Some advanced features are only available through the official app. Use the app for those functions.
 
@@ -239,6 +276,7 @@ To check your logs for troubleshooting:
 3. Look for error messages that can help identify the issue
 
 If you need further assistance, please open an issue on the [GitHub repository](https://github.com/kclif9/hassactronneo/issues) with the following information:
+
 - Description of the problem
 - Relevant log entries
 - Home Assistant version

--- a/custom_components/actronair/__init__.py
+++ b/custom_components/actronair/__init__.py
@@ -1,15 +1,12 @@
 """The Actron Air integration."""
 
-from actron_neo_api import (
-    ActronAirACSystem,
-    ActronAirAPI,
-    ActronAirAPIError,
-    ActronAirAuthError,
-)
+from actron_neo_api import ActronAirAPI, ActronAirAPIError, ActronAirAuthError
+from actron_neo_api.models.system import ActronAirSystemInfo
 
 from homeassistant.const import CONF_API_TOKEN, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers import entity_registry as er
 
 from .const import _LOGGER, DOMAIN
 from .coordinator import (
@@ -18,14 +15,109 @@ from .coordinator import (
     ActronAirSystemCoordinator,
 )
 
-PLATFORM = [Platform.CLIMATE, Platform.COVER, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.CLIMATE, Platform.COVER, Platform.SENSOR, Platform.SWITCH]
+
+# Sensors whose unique_id was a bare translation_key (no serial prefix).
+# These need to be prefixed with the system serial number.
+_SENSOR_UID_MIGRATE = {
+    "compressor_chasing_temperature",
+    "compressor_live_temperature",
+    "compressor_mode",
+    "compressor_speed",
+    "compressor_power",
+    "outdoor_temperature",
+}
+
+# Sensors that moved from the sensor platform to binary_sensor.
+# Old unique_id was a bare translation_key; new unique_id is {serial}_{key}.
+_SENSOR_TO_BINARY_SENSOR = {"clean_filter", "defrost_mode"}
+
+# Peripheral sensor key renames (old suffix → new suffix).
+_PERIPHERAL_KEY_RENAMES = {
+    "battery": "peripheral_battery",
+    "temperature": "peripheral_temperature",
+    "humidity": "peripheral_humidity",
+}
+
+
+async def _async_migrate_entities(
+    hass: HomeAssistant,
+    entry: ActronAirConfigEntry,
+    serials: set[str],
+) -> None:
+    """Migrate entity unique IDs from pre-0.11 format.
+
+    Handles:
+    - Main sensor unique_id: bare key → {serial}_{key}
+    - clean_filter / defrost_mode: sensor platform → binary_sensor platform
+    - Cover unique_id: *_position → *_zone_position
+    - Peripheral sensor key renames: {periph_serial}_{old} → {periph_serial}_{new}
+    """
+    registry = er.async_get(hass)
+    entries = er.async_entries_for_config_entry(registry, entry.entry_id)
+    if not entries:
+        return
+
+    # For main sensors that had no serial prefix, we can only safely migrate
+    # when there is exactly one system (multi-system was already broken).
+    single_serial = next(iter(serials)) if len(serials) == 1 else None
+
+    for entity_entry in entries:
+        new_uid: str | None = None
+
+        if entity_entry.domain == "sensor":
+            uid = entity_entry.unique_id
+
+            # Main sensors → prefix with serial
+            if uid in _SENSOR_UID_MIGRATE and single_serial:
+                new_uid = f"{single_serial}_{uid}"
+
+            # Sensors migrated to binary_sensor: remove so the new platform
+            # can recreate them.
+            elif uid in _SENSOR_TO_BINARY_SENSOR:
+                _LOGGER.info(
+                    "Removing %s (migrated to binary_sensor platform)",
+                    entity_entry.entity_id,
+                )
+                registry.async_remove(entity_entry.entity_id)
+                continue
+
+            # Peripheral key renames: {periph_serial}_{old} → {periph_serial}_{new}
+            elif "_zone_" not in uid:
+                for old_suffix, new_suffix in _PERIPHERAL_KEY_RENAMES.items():
+                    if uid.endswith(f"_{old_suffix}"):
+                        prefix = uid[: -(len(old_suffix) + 1)]
+                        if prefix and prefix not in serials:
+                            new_uid = f"{prefix}_{new_suffix}"
+                        break
+
+        elif entity_entry.domain == "cover":
+            # Cover: {serial}_zone_{id}_position → {serial}_zone_{id}_zone_position
+            if (
+                entity_entry.unique_id.endswith("_position")
+                and "_zone_" in entity_entry.unique_id
+            ):
+                new_uid = entity_entry.unique_id.replace(
+                    "_position", "_zone_position"
+                )
+
+        if new_uid and new_uid != entity_entry.unique_id:
+            _LOGGER.info(
+                "Migrating %s unique_id: %s → %s",
+                entity_entry.entity_id,
+                entity_entry.unique_id,
+                new_uid,
+            )
+            registry.async_update_entity(
+                entity_entry.entity_id, new_unique_id=new_uid
+            )
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ActronAirConfigEntry) -> bool:
     """Set up Actron Air integration from a config entry."""
 
     api = ActronAirAPI(refresh_token=entry.data[CONF_API_TOKEN])
-    systems: list[ActronAirACSystem] = []
+    systems: list[ActronAirSystemInfo] = []
 
     try:
         systems = await api.get_ac_systems()
@@ -36,25 +128,30 @@ async def async_setup_entry(hass: HomeAssistant, entry: ActronAirConfigEntry) ->
             translation_key="auth_error",
         ) from err
     except ActronAirAPIError as err:
-        _LOGGER.error("API error while setting up Actron Air integration: %s", err)
-        raise
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="setup_connection_error",
+        ) from err
 
     system_coordinators: dict[str, ActronAirSystemCoordinator] = {}
     for system in systems:
         coordinator = ActronAirSystemCoordinator(hass, entry, api, system)
-        _LOGGER.debug("Setting up coordinator for system: %s", system["serial"])
+        _LOGGER.debug("Setting up coordinator for system: %s", system.serial)
         await coordinator.async_config_entry_first_refresh()
-        system_coordinators[system["serial"]] = coordinator
+        system_coordinators[system.serial] = coordinator
 
     entry.runtime_data = ActronAirRuntimeData(
         api=api,
         system_coordinators=system_coordinators,
     )
 
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORM)
+    await _async_migrate_entities(
+        hass, entry, {s.serial for s in systems}
+    )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ActronAirConfigEntry) -> bool:
     """Unload a config entry."""
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORM)
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/custom_components/actronair/binary_sensor.py
+++ b/custom_components/actronair/binary_sensor.py
@@ -1,0 +1,80 @@
+"""Binary sensor platform for Actron Air integration."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from actron_neo_api import ActronAirStatus
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import ActronAirConfigEntry, ActronAirSystemCoordinator
+from .entity import ActronAirAcEntity
+
+PARALLEL_UPDATES = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class ActronAirBinarySensorEntityDescription(BinarySensorEntityDescription):
+    """Describes Actron Air binary sensor entity."""
+
+    value_fn: Callable[[ActronAirStatus], bool | None]
+
+
+BINARY_SENSORS: tuple[ActronAirBinarySensorEntityDescription, ...] = (
+    ActronAirBinarySensorEntityDescription(
+        key="clean_filter",
+        translation_key="clean_filter",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda status: status.clean_filter,
+    ),
+    ActronAirBinarySensorEntityDescription(
+        key="defrost_mode",
+        translation_key="defrost_mode",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda status: status.defrost_mode,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ActronAirConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Actron Air binary sensor entities."""
+    system_coordinators = entry.runtime_data.system_coordinators
+    async_add_entities(
+        ActronAirBinarySensor(coordinator, description)
+        for coordinator in system_coordinators.values()
+        for description in BINARY_SENSORS
+    )
+
+
+class ActronAirBinarySensor(ActronAirAcEntity, BinarySensorEntity):
+    """Representation of an Actron Air binary sensor."""
+
+    entity_description: ActronAirBinarySensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: ActronAirSystemCoordinator,
+        description: ActronAirBinarySensorEntityDescription,
+    ) -> None:
+        """Initialize the binary sensor."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.serial_number}_{description.key}"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if the binary sensor is on."""
+        return self.entity_description.value_fn(self.coordinator.data)

--- a/custom_components/actronair/climate.py
+++ b/custom_components/actronair/climate.py
@@ -15,12 +15,12 @@ from homeassistant.components.climate import (
 )
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import ActronAirConfigEntry, ActronAirSystemCoordinator
+from .entity import ActronAirAcEntity, ActronAirZoneEntity, actron_air_command
 
 PARALLEL_UPDATES = 0
 
@@ -38,6 +38,7 @@ HVAC_MODE_MAPPING_ACTRONAIR_TO_HA = {
     "HEAT": HVACMode.HEAT,
     "FAN": HVACMode.FAN_ONLY,
     "AUTO": HVACMode.AUTO,
+    "DRY": HVACMode.DRY,
     "OFF": HVACMode.OFF,
 }
 HVAC_MODE_MAPPING_HA_TO_ACTRONAIR = {
@@ -56,8 +57,7 @@ async def async_setup_entry(
 
     for coordinator in system_coordinators.values():
         status = coordinator.data
-        name = status.ac_system.system_name
-        entities.append(ActronSystemClimate(coordinator, name))
+        entities.append(ActronSystemClimate(coordinator))
 
         entities.extend(
             ActronZoneClimate(coordinator, zone)
@@ -68,10 +68,9 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class BaseClimateEntity(CoordinatorEntity[ActronAirSystemCoordinator], ClimateEntity):
+class ActronAirClimateEntity(ClimateEntity):
     """Base class for Actron Air climate entities."""
 
-    _attr_has_entity_name = True
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_supported_features = (
         ClimateEntityFeature.TARGET_TEMPERATURE
@@ -81,45 +80,29 @@ class BaseClimateEntity(CoordinatorEntity[ActronAirSystemCoordinator], ClimateEn
     )
     _attr_name = None
     _attr_fan_modes = list(FAN_MODE_MAPPING_ACTRONAIR_TO_HA.values())
-    _attr_hvac_modes = list(HVAC_MODE_MAPPING_ACTRONAIR_TO_HA.values())
+
+
+class ActronSystemClimate(ActronAirAcEntity, ActronAirClimateEntity):
+    """Representation of the Actron Air system."""
 
     def __init__(
         self,
         coordinator: ActronAirSystemCoordinator,
-        name: str,
     ) -> None:
         """Initialize an Actron Air unit."""
         super().__init__(coordinator)
-        self._serial_number = coordinator.serial_number
+        self._attr_unique_id = self._serial_number
 
-
-class ActronSystemClimate(BaseClimateEntity):
-    """Representation of the Actron Air system."""
-
-    _attr_supported_features = (
-        ClimateEntityFeature.TARGET_TEMPERATURE
-        | ClimateEntityFeature.FAN_MODE
-        | ClimateEntityFeature.TURN_ON
-        | ClimateEntityFeature.TURN_OFF
-    )
-
-    def __init__(
-        self,
-        coordinator: ActronAirSystemCoordinator,
-        name: str,
-    ) -> None:
-        """Initialize an Actron Air unit."""
-        super().__init__(coordinator, name)
-        serial_number = coordinator.serial_number
-        self._attr_unique_id = serial_number
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, serial_number)},
-            name=self._status.ac_system.system_name,
-            manufacturer="Actron Air",
-            model_id=self._status.ac_system.master_wc_model,
-            sw_version=self._status.ac_system.master_wc_firmware_version,
-            serial_number=serial_number,
-        )
+    @property
+    def hvac_modes(self) -> list[HVACMode]:
+        """Return the list of supported HVAC modes."""
+        modes = [
+            HVAC_MODE_MAPPING_ACTRONAIR_TO_HA[mode]
+            for mode in self._status.user_aircon_settings.supported_modes
+            if mode in HVAC_MODE_MAPPING_ACTRONAIR_TO_HA
+        ]
+        modes.append(HVACMode.OFF)
+        return modes
 
     @property
     def min_temp(self) -> float:
@@ -166,23 +149,30 @@ class ActronSystemClimate(BaseClimateEntity):
         """Return the target temperature."""
         return self._status.user_aircon_settings.temperature_setpoint_cool_c
 
+    @actron_air_command
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set a new fan mode."""
-        api_fan_mode = FAN_MODE_MAPPING_HA_TO_ACTRONAIR.get(fan_mode.lower())
+        api_fan_mode = FAN_MODE_MAPPING_HA_TO_ACTRONAIR[fan_mode]
         await self._status.user_aircon_settings.set_fan_mode(api_fan_mode)
 
+    @actron_air_command
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the HVAC mode."""
-        ac_mode = HVAC_MODE_MAPPING_HA_TO_ACTRONAIR.get(hvac_mode)
+        ac_mode = HVAC_MODE_MAPPING_HA_TO_ACTRONAIR[hvac_mode]
         await self._status.ac_system.set_system_mode(ac_mode)
 
+    @actron_air_command
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set the temperature."""
-        temp = kwargs.get(ATTR_TEMPERATURE)
-        await self._status.user_aircon_settings.set_temperature(temperature=temp)
+        if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="temperature_missing",
+            )
+        await self._status.user_aircon_settings.set_temperature(temperature=temperature)
 
 
-class ActronZoneClimate(BaseClimateEntity):
+class ActronZoneClimate(ActronAirZoneEntity, ActronAirClimateEntity):
     """Representation of a zone within the Actron Air system."""
 
     _attr_supported_features = (
@@ -197,18 +187,20 @@ class ActronZoneClimate(BaseClimateEntity):
         zone: ActronAirZone,
     ) -> None:
         """Initialize an Actron Air unit."""
-        super().__init__(coordinator, zone.title)
-        serial_number = coordinator.serial_number
-        self._zone_id: int = zone.zone_id
-        self._attr_unique_id: str = f"{serial_number}_zone_{zone.zone_id}"
-        self._attr_device_info: DeviceInfo = DeviceInfo(
-            identifiers={(DOMAIN, self._attr_unique_id)},
-            name=zone.title,
-            manufacturer="Actron Air",
-            model="Zone",
-            suggested_area=zone.title,
-            via_device=(DOMAIN, serial_number),
-        )
+        super().__init__(coordinator, zone)
+        self._attr_unique_id: str = self._zone_identifier
+
+    @property
+    def hvac_modes(self) -> list[HVACMode]:
+        """Return the list of supported HVAC modes."""
+        status = self.coordinator.data
+        modes = [
+            HVAC_MODE_MAPPING_ACTRONAIR_TO_HA[mode]
+            for mode in status.user_aircon_settings.supported_modes
+            if mode in HVAC_MODE_MAPPING_ACTRONAIR_TO_HA
+        ]
+        modes.append(HVACMode.OFF)
+        return modes
 
     @property
     def min_temp(self) -> float:
@@ -219,12 +211,6 @@ class ActronZoneClimate(BaseClimateEntity):
     def max_temp(self) -> float:
         """Return the maximum temperature that can be set."""
         return self._zone.max_temp
-
-    @property
-    def _zone(self) -> ActronAirZone:
-        """Get the current zone data from the coordinator."""
-        status = self.coordinator.data
-        return status.zones[self._zone_id]
 
     @property
     def hvac_mode(self) -> HVACMode | None:
@@ -249,11 +235,18 @@ class ActronZoneClimate(BaseClimateEntity):
         """Return the target temperature."""
         return self._zone.temperature_setpoint_cool_c
 
+    @actron_air_command
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the HVAC mode."""
         is_enabled = hvac_mode != HVACMode.OFF
         await self._zone.enable(is_enabled)
 
+    @actron_air_command
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set the temperature."""
-        await self._zone.set_temperature(temperature=kwargs["temperature"])
+        if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="temperature_missing",
+            )
+        await self._zone.set_temperature(temperature=temperature)

--- a/custom_components/actronair/config_flow.py
+++ b/custom_components/actronair/config_flow.py
@@ -23,7 +23,7 @@ class ActronAirConfigFlow(ConfigFlow, domain=DOMAIN):
         self._user_code: str = ""
         self._verification_uri: str = ""
         self._expires_minutes: str = "30"
-        self.login_task: asyncio.Task | None = None
+        self.login_task: asyncio.Task[None] | None = None
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -38,10 +38,10 @@ class ActronAirConfigFlow(ConfigFlow, domain=DOMAIN):
                 _LOGGER.error("OAuth2 flow failed: %s", err)
                 return self.async_abort(reason="oauth2_error")
 
-            self._device_code = device_code_response["device_code"]
-            self._user_code = device_code_response["user_code"]
-            self._verification_uri = device_code_response["verification_uri_complete"]
-            self._expires_minutes = str(device_code_response["expires_in"] // 60)
+            self._device_code = device_code_response.device_code
+            self._user_code = device_code_response.user_code
+            self._verification_uri = device_code_response.verification_uri_complete
+            self._expires_minutes = str(device_code_response.expires_in // 60)
 
         async def _wait_for_authorization() -> None:
             """Wait for the user to authorize the device."""
@@ -94,7 +94,8 @@ class ActronAirConfigFlow(ConfigFlow, domain=DOMAIN):
             _LOGGER.error("Error getting user info: %s", err)
             return self.async_abort(reason="oauth2_error")
 
-        unique_id = str(user_data["id"])
+        unique_id = user_data.sub
+        await self.async_set_unique_id(unique_id)
 
         # Check if this is a reauth flow
         if self.source == SOURCE_REAUTH:
@@ -104,10 +105,9 @@ class ActronAirConfigFlow(ConfigFlow, domain=DOMAIN):
                 data_updates={CONF_API_TOKEN: self._api.refresh_token_value},
             )
 
-        await self.async_set_unique_id(unique_id)
         self._abort_if_unique_id_configured()
         return self.async_create_entry(
-            title=user_data["email"],
+            title=user_data.email,
             data={CONF_API_TOKEN: self._api.refresh_token_value},
         )
 
@@ -120,7 +120,7 @@ class ActronAirConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_show_form(
                 step_id="timeout",
             )
-        del self.login_task
+        self.login_task = None
         return await self.async_step_user()
 
     async def async_step_reauth(

--- a/custom_components/actronair/const.py
+++ b/custom_components/actronair/const.py
@@ -1,10 +1,6 @@
 """Constants used by Actron Air integration."""
 
-from datetime import timedelta
 import logging
-
-from homeassistant.const import Platform
 
 _LOGGER = logging.getLogger(__package__)
 DOMAIN = "actron_air"
-PLATFORM = [Platform.CLIMATE, Platform.COVER, Platform.SENSOR, Platform.SWITCH]

--- a/custom_components/actronair/coordinator.py
+++ b/custom_components/actronair/coordinator.py
@@ -6,22 +6,25 @@ from dataclasses import dataclass
 from datetime import timedelta
 
 from actron_neo_api import (
-    ActronAirACSystem,
     ActronAirAPI,
+    ActronAirAPIError,
     ActronAirAuthError,
     ActronAirStatus,
 )
+from actron_neo_api.models.system import ActronAirSystemInfo
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
 from .const import _LOGGER, DOMAIN
 
 SCAN_INTERVAL = timedelta(seconds=30)
 STALE_DEVICE_TIMEOUT = timedelta(minutes=5)
+ERROR_NO_SYSTEMS_FOUND = "no_systems_found"
+ERROR_UNKNOWN = "unknown_error"
 
 
 @dataclass
@@ -35,7 +38,7 @@ class ActronAirRuntimeData:
 type ActronAirConfigEntry = ConfigEntry[ActronAirRuntimeData]
 
 
-class ActronAirSystemCoordinator(DataUpdateCoordinator[ActronAirACSystem]):
+class ActronAirSystemCoordinator(DataUpdateCoordinator[ActronAirStatus]):
     """System coordinator for Actron Air integration."""
 
     def __init__(
@@ -43,7 +46,7 @@ class ActronAirSystemCoordinator(DataUpdateCoordinator[ActronAirACSystem]):
         hass: HomeAssistant,
         entry: ActronAirConfigEntry,
         api: ActronAirAPI,
-        system: ActronAirACSystem,
+        system: ActronAirSystemInfo,
     ) -> None:
         """Initialize the coordinator."""
         super().__init__(
@@ -54,7 +57,7 @@ class ActronAirSystemCoordinator(DataUpdateCoordinator[ActronAirACSystem]):
             config_entry=entry,
         )
         self.system = system
-        self.serial_number = system["serial"]
+        self.serial_number = system.serial
         self.api = api
         self.status = self.api.state_manager.get_status(self.serial_number)
         self.last_seen = dt_util.utcnow()
@@ -68,8 +71,21 @@ class ActronAirSystemCoordinator(DataUpdateCoordinator[ActronAirACSystem]):
                 translation_domain=DOMAIN,
                 translation_key="auth_error",
             ) from err
+        except ActronAirAPIError as err:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="update_error",
+                translation_placeholders={"error": repr(err)},
+            ) from err
 
-        self.status = self.api.state_manager.get_status(self.serial_number)
+        status = self.api.state_manager.get_status(self.serial_number)
+        if status is None:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="update_error",
+                translation_placeholders={"error": "Status not available"},
+            )
+        self.status = status
         self.last_seen = dt_util.utcnow()
         return self.status
 

--- a/custom_components/actronair/cover.py
+++ b/custom_components/actronair/cover.py
@@ -2,14 +2,18 @@
 
 from actron_neo_api import ActronAirZone
 
-from homeassistant.components.cover import CoverDeviceClass, CoverEntity, CoverEntityFeature
+from homeassistant.components.cover import (
+    CoverDeviceClass,
+    CoverEntity,
+    CoverEntityFeature,
+)
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
 from .coordinator import ActronAirConfigEntry, ActronAirSystemCoordinator
+from .entity import ActronAirZoneEntity
+
+PARALLEL_UPDATES = 0
 
 
 async def async_setup_entry(
@@ -19,52 +23,36 @@ async def async_setup_entry(
 ) -> None:
     """Set up Actron Air cover entities."""
     system_coordinators = entry.runtime_data.system_coordinators
-    entities: list[CoverEntity] = []
-
-    for coordinator in system_coordinators.values():
-        status = coordinator.data
-        entities.extend(
-            ZonePositionSensor(coordinator, zone)
-            for zone in status.remote_zone_info
-            if zone.exists
-        )
-
-    async_add_entities(entities)
+    async_add_entities(
+        ActronAirZoneDamper(coordinator, zone)
+        for coordinator in system_coordinators.values()
+        for zone in coordinator.data.remote_zone_info
+        if zone.exists
+    )
 
 
-class ZonePositionSensor(CoordinatorEntity, CoverEntity):
-    """Position sensor for Actron Air zone."""
+class ActronAirZoneDamper(ActronAirZoneEntity, CoverEntity):
+    """Damper position cover for an Actron Air zone."""
 
-    _attr_has_entity_name: bool = True
-    _attr_supported_features: CoverEntityFeature = None
-    _attr_translation_key: str = "zone_position"
-    _attr_device_class: CoverDeviceClass = CoverDeviceClass.DAMPER
+    _attr_device_class = CoverDeviceClass.DAMPER
+    _attr_supported_features = CoverEntityFeature(0)
+    _attr_translation_key = "zone_position"
 
     def __init__(
         self,
         coordinator: ActronAirSystemCoordinator,
         zone: ActronAirZone,
     ) -> None:
-        """Initialize the sensor."""
-        super().__init__(coordinator)
-        self._serial_number: str = coordinator.serial_number
-        self._zone: ActronAirZone = zone
-        self._attr_unique_id: str = f"{self._serial_number}_zone_{self._zone.zone_id}_position"
-        self._attr_device_info: DeviceInfo = DeviceInfo(
-            identifiers={(DOMAIN, f"{self._serial_number}_zone_{self._zone.zone_id}")},
-        )
+        """Initialize the cover."""
+        super().__init__(coordinator, zone)
+        self._attr_unique_id = f"{self._zone_identifier}_{self._attr_translation_key}"
 
     @property
-    def available(self) -> bool:
-        """Return True if entity is available."""
-        return not self.coordinator.is_device_stale()
-
-    @property
-    def current_cover_position(self) -> str | None:
-        """Return the state of the sensor."""
+    def current_cover_position(self) -> int | None:
+        """Return the current position of the damper."""
         return self._zone.zone_position
 
     @property
     def is_closed(self) -> bool:
-        """Return True if the cover is closed."""
+        """Return True if the damper is closed."""
         return self.current_cover_position == 0

--- a/custom_components/actronair/diagnostics.py
+++ b/custom_components/actronair/diagnostics.py
@@ -1,29 +1,35 @@
 """Diagnostics support for Actron Air."""
+
 from __future__ import annotations
 
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.const import CONF_API_TOKEN, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_API_TOKEN
 from homeassistant.core import HomeAssistant
 
-from . import ActronAirConfigEntry
+from .coordinator import ActronAirConfigEntry
 
-TO_REDACT = {CONF_API_TOKEN, CONF_PASSWORD, CONF_USERNAME, "email", "id", "serial"}
+TO_REDACT = {CONF_API_TOKEN, "master_serial", "serial_number", "serial"}
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, entry: ActronAirConfigEntry
+    hass: HomeAssistant,
+    entry: ActronAirConfigEntry,
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator = entry.runtime_data
-
-    # Create a cleaned/redacted version of the API status data
-    data = {
-        "api_status": coordinator.data,
-        "systems": coordinator.api.systems,
-        "config_entry": entry.as_dict(),
+    coordinators: dict[int, Any] = {}
+    for idx, coordinator in enumerate(entry.runtime_data.system_coordinators.values()):
+        coordinators[idx] = {
+            "system": async_redact_data(
+                coordinator.system.model_dump(mode="json"), TO_REDACT
+            ),
+            "status": async_redact_data(
+                coordinator.data.model_dump(mode="json", exclude={"last_known_state"}),
+                TO_REDACT,
+            ),
+        }
+    return {
+        "entry_data": async_redact_data(entry.data, TO_REDACT),
+        "coordinators": coordinators,
     }
-
-    # Redact sensitive information
-    return async_redact_data(data, TO_REDACT)

--- a/custom_components/actronair/entity.py
+++ b/custom_components/actronair/entity.py
@@ -1,287 +1,128 @@
-"""Sensor platform for Actron Air integration."""
+"""Base entity classes for Actron Air integration."""
 
-from actron_neo_api import ActronAirPeripheral, ActronAirZone
+from collections.abc import Callable, Coroutine
+from functools import wraps
+from typing import Any, Concatenate
 
-from homeassistant.components.sensor import (
-    SensorDeviceClass,
-)
-from homeassistant.const import EntityCategory, PERCENTAGE, UnitOfTemperature
+from actron_neo_api import ActronAirAPIError, ActronAirZone
+from actron_neo_api.models.zone import ActronAirPeripheral
+
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .coordinator import ActronAirSystemCoordinator
 from .const import DOMAIN
-
-DIAGNOSTIC_CATEGORY = EntityCategory.DIAGNOSTIC
-CONFIG_CATEGORY = EntityCategory.CONFIG
+from .coordinator import ActronAirSystemCoordinator
 
 
-class EntitySensor(CoordinatorEntity, Entity):
-    """Representation of a diagnostic sensor."""
+def actron_air_command[_EntityT: ActronAirEntity, **_P](
+    func: Callable[Concatenate[_EntityT, _P], Coroutine[Any, Any, Any]],
+) -> Callable[Concatenate[_EntityT, _P], Coroutine[Any, Any, None]]:
+    """Decorator for Actron Air API calls.
+
+    Handles ActronAirAPIError exceptions, and requests a coordinator update
+    to update the status of the devices as soon as possible.
+    """
+
+    @wraps(func)
+    async def wrapper(self: _EntityT, /, *args: _P.args, **kwargs: _P.kwargs) -> None:
+        """Wrap API calls with exception handling."""
+        try:
+            await func(self, *args, **kwargs)
+        except ActronAirAPIError as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="api_error",
+                translation_placeholders={"error": str(err)},
+            ) from err
+        self.coordinator.async_set_updated_data(self.coordinator.data)
+
+    return wrapper
+
+
+class ActronAirEntity(CoordinatorEntity[ActronAirSystemCoordinator]):
+    """Base class for Actron Air entities."""
 
     _attr_has_entity_name = True
 
-    def __init__(
-        self,
-        coordinator: ActronAirSystemCoordinator,
-        translation_key: str,
-        sensor_name: str,
-        device_class=None,
-        unit_of_measurement=None,
-        is_diagnostic=False,
-        entity_category=None,
-        state_class=None,
-        enabled_default=True,
-    ) -> None:
-        """Initialise diagnostic sensor."""
+    def __init__(self, coordinator: ActronAirSystemCoordinator) -> None:
+        """Initialize the entity."""
         super().__init__(coordinator)
-        self._sensor_name = sensor_name
-        self._is_diagnostic = is_diagnostic
-        self._entity_category = entity_category
-        self._enabled_default = enabled_default
-        self._attr_device_class = device_class
-        self._attr_unit_of_measurement = unit_of_measurement
-        self._attr_translation_key = translation_key
-        self._attr_state_class = state_class
-        self._attr_unique_id = translation_key
         self._serial_number = coordinator.serial_number
-        self._attr_device_info: DeviceInfo = DeviceInfo(
-            identifiers={(DOMAIN, self._serial_number)},
-        )
-
-    @property
-    def _status(self):
-        """Get the current status from the coordinator."""
-        return self.coordinator.data
 
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
         return not self.coordinator.is_device_stale()
 
-    @property
-    def state(self):
-        """Return the state of the sensor."""
-        return getattr(self._status, self._sensor_name, None)
 
-    @property
-    def entity_category(self) -> EntityCategory | None:
-        """Return the entity category."""
-        if self._entity_category:
-            return self._entity_category
-        return DIAGNOSTIC_CATEGORY if self._is_diagnostic else None
+class ActronAirAcEntity(ActronAirEntity):
+    """Base class for Actron Air entities."""
 
-    @property
-    def entity_registry_enabled_default(self) -> bool:
-        """Return if the entity should be enabled when first added to the entity registry."""
-        return self._enabled_default
+    def __init__(self, coordinator: ActronAirSystemCoordinator) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._serial_number)},
+            name=coordinator.data.ac_system.system_name,
+            manufacturer="Actron Air",
+            model_id=coordinator.data.ac_system.master_wc_model,
+            sw_version=coordinator.data.ac_system.master_wc_firmware_version,
+            serial_number=self._serial_number,
+        )
 
 
-class BaseZoneSensor(CoordinatorEntity, Entity):
-    """Base class for Actron Air sensors."""
-
-    _attr_has_entity_name = True
+class ActronAirZoneEntity(ActronAirEntity):
+    """Base class for Actron Air zone entities."""
 
     def __init__(
         self,
         coordinator: ActronAirSystemCoordinator,
         zone: ActronAirZone,
-        translation_key: str,
-        state_key: str,
-        device_class: SensorDeviceClass,
-        unit_of_measurement,
-        entity_category=None,
-        enabled_default: bool = True,
     ) -> None:
-        """Initialize the sensor."""
+        """Initialize the entity."""
         super().__init__(coordinator)
-        self._serial_number = coordinator.serial_number
         self._zone_id: int = zone.zone_id
-        self._state_key: str = state_key
-        self._entity_category = entity_category
-        self._enabled_default: bool = enabled_default
-        self._attr_device_class: SensorDeviceClass = device_class
-        self._attr_unit_of_measurement = unit_of_measurement
-        self._attr_translation_key = translation_key
-        self._attr_unique_id: str = f"{self._serial_number}_zone_{zone.zone_id}_{translation_key}"
-        self._attr_device_info: DeviceInfo = DeviceInfo(
-            identifiers={(DOMAIN, f"{self._serial_number}_zone_{zone.zone_id}")},
+        self._zone_identifier = f"{self._serial_number}_zone_{zone.zone_id}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._zone_identifier)},
+            name=zone.title,
+            manufacturer="Actron Air",
+            model="Zone",
+            suggested_area=zone.title,
+            via_device=(DOMAIN, self._serial_number),
         )
 
     @property
     def _zone(self) -> ActronAirZone:
         """Get the current zone data from the coordinator."""
-        status = self.coordinator.data
-        return status.zones.get(self._zone_id)
-
-    @property
-    def available(self) -> bool:
-        """Return True if entity is available."""
-        return not self.coordinator.is_device_stale()
-
-    @property
-    def state(self) -> str | None:
-        """Return the state of the sensor."""
-        return getattr(self._zone, self._state_key, None)
-
-    @property
-    def entity_category(self) -> EntityCategory | None:
-        """Return the entity category."""
-        return self._entity_category
-
-    @property
-    def entity_registry_enabled_default(self) -> bool:
-        """Return if the entity should be enabled when first added to the entity registry."""
-        return self._enabled_default
+        return self.coordinator.data.zones[self._zone_id]
 
 
-class ZoneTemperatureSensor(BaseZoneSensor):
-    """Temperature sensor for Actron Air zone."""
-
-    def __init__(self, coordinator: ActronAirSystemCoordinator, zone) -> None:
-        """Initialize the temperature sensor."""
-        super().__init__(
-            coordinator,
-            zone,
-            "temperature",
-            "live_temp_c",
-            SensorDeviceClass.TEMPERATURE,
-            UnitOfTemperature.CELSIUS
-        )
-
-
-class ZoneHumiditySensor(BaseZoneSensor):
-    """Humidity sensor for Actron Air zone."""
-
-    def __init__(self, coordinator: ActronAirSystemCoordinator, zone) -> None:
-        """Initialize the humidity sensor."""
-        super().__init__(
-            coordinator,
-            zone,
-            "humidity",
-            "live_humidity_pc",
-            SensorDeviceClass.HUMIDITY,
-            PERCENTAGE
-        )
-
-
-class BasePeripheralSensor(CoordinatorEntity, Entity):
-    """Base class for Actron Air sensors."""
-
-    _attr_has_entity_name = True
+class ActronAirPeripheralEntity(ActronAirEntity):
+    """Base class for Actron Air peripheral entities."""
 
     def __init__(
         self,
         coordinator: ActronAirSystemCoordinator,
         peripheral: ActronAirPeripheral,
-        translation_key: str,
-        state_key: str,
-        device_class: SensorDeviceClass,
-        unit_of_measurement,
-        entity_category=None,
-        enabled_default=True,
     ) -> None:
-        """Initialize the sensor."""
+        """Initialize the entity."""
         super().__init__(coordinator)
-        self._ac_serial = coordinator.serial_number
-        self._peripheral_id = peripheral.logical_address
-        self._state_key = state_key
-        self._serial_number = peripheral.serial_number
-        self._entity_category = entity_category
-        self._enabled_default = enabled_default
-        self._attr_device_class = device_class
-        self._attr_unit_of_measurement = unit_of_measurement
-        self._attr_translation_key = translation_key
-        self._attr_unique_id: str = (
-            f"{self._serial_number}_{translation_key}"
-        )
-
-        suggested_area = None
-        if hasattr(peripheral, 'zones') and len(peripheral.zones) == 1:
-            zone = peripheral.zones[0]
-            if hasattr(zone, 'title') and zone.title:
-                suggested_area = zone.title
-
-        self._attr_device_info: DeviceInfo = DeviceInfo(
-            identifiers={(DOMAIN, self._serial_number)},
-            name=f"{peripheral.device_type} {peripheral.logical_address}",
+        self._peripheral_serial = peripheral.serial_number
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, peripheral.serial_number)},
+            name=f"Sensor {peripheral.serial_number}",
             manufacturer="Actron Air",
             model=peripheral.device_type,
-            suggested_area=suggested_area,
+            serial_number=peripheral.serial_number,
+            via_device=(DOMAIN, self._serial_number),
         )
 
     @property
-    def _peripheral(self) -> ActronAirPeripheral:
+    def _peripheral(self) -> ActronAirPeripheral | None:
         """Get the current peripheral data from the coordinator."""
         for peripheral in self.coordinator.data.peripherals:
-            if peripheral.logical_address == self._peripheral_id:
+            if peripheral.serial_number == self._peripheral_serial:
                 return peripheral
         return None
-
-    @property
-    def available(self) -> bool:
-        """Return True if entity is available."""
-        return not self.coordinator.is_device_stale()
-
-    @property
-    def state(self) -> str | None:
-        """Return the state of the sensor."""
-        return getattr(self._peripheral, self._state_key, None)
-
-    @property
-    def entity_category(self) -> EntityCategory | None:
-        """Return the entity category."""
-        return self._entity_category
-
-    @property
-    def entity_registry_enabled_default(self) -> bool:
-        """Return if the entity should be enabled when first added to the entity registry."""
-        return self._enabled_default
-
-
-class PeripheralBatterySensor(BasePeripheralSensor):
-    """Battery sensor for Actron Air zone."""
-
-    def __init__(self, coordinator: ActronAirSystemCoordinator, peripheral: ActronAirPeripheral) -> None:
-        """Initialize the battery sensor."""
-        super().__init__(
-            coordinator,
-            peripheral,
-            "battery",
-            "battery_level",
-            SensorDeviceClass.BATTERY,
-            PERCENTAGE,
-            entity_category=DIAGNOSTIC_CATEGORY,
-            enabled_default=True,
-        )
-
-
-class PeripheralTemperatureSensor(BasePeripheralSensor):
-    """Temperature sensor for Actron Air zone."""
-
-    def __init__(self, coordinator: ActronAirSystemCoordinator, peripheral: ActronAirPeripheral) -> None:
-        """Initialize the temperature sensor."""
-        super().__init__(
-            coordinator,
-            peripheral,
-            "temperature",
-            "temperature",
-            SensorDeviceClass.TEMPERATURE,
-            UnitOfTemperature.CELSIUS
-        )
-
-
-class PeripheralHumiditySensor(BasePeripheralSensor):
-    """Humidity sensor for Actron Air zone."""
-
-    def __init__(self, coordinator: ActronAirSystemCoordinator, peripheral: ActronAirPeripheral) -> None:
-        """Initialize the humidity sensor."""
-        super().__init__(
-            coordinator,
-            peripheral,
-            "humidity",
-            "humidity",
-            SensorDeviceClass.HUMIDITY,
-            PERCENTAGE
-        )

--- a/custom_components/actronair/manifest.json
+++ b/custom_components/actronair/manifest.json
@@ -16,7 +16,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/kclif9/hassactronneo/issues",
   "requirements": [
-    "actron-neo-api==0.4.1"
+    "actron-neo-api==0.5.5"
   ],
   "version": "0.10.8"
 }

--- a/custom_components/actronair/quality_scale.yaml
+++ b/custom_components/actronair/quality_scale.yaml
@@ -26,7 +26,7 @@ rules:
   unique-config-entry: done
 
   # Silver
-  action-exceptions: todo
+  action-exceptions: done
   config-entry-unloading: done
   docs-configuration-parameters:
     status: exempt
@@ -36,12 +36,12 @@ rules:
   integration-owner: done
   log-when-unavailable: done
   parallel-updates: done
-  reauthentication-flow: todo
-  test-coverage: todo
+  reauthentication-flow: done
+  test-coverage: done
 
   # Gold
   devices: done
-  diagnostics: todo
+  diagnostics: done
   discovery-update-info:
     status: exempt
     comment: This integration uses DHCP discovery, however is cloud polling. Therefore there is no information to update.
@@ -54,18 +54,12 @@ rules:
   docs-troubleshooting: done
   docs-use-cases: done
   dynamic-devices: todo
-  entity-category:
-    status: exempt
-    comment: This integration does not use entity categories.
-  entity-device-class:
-    status: exempt
-    comment: This integration does not use entity device classes.
-  entity-disabled-by-default:
-    status: exempt
-    comment: Not required for this integration at this stage.
-  entity-translations: todo
-  exception-translations: todo
-  icon-translations: todo
+  entity-category: done
+  entity-device-class: todo
+  entity-disabled-by-default: todo
+  entity-translations: done
+  exception-translations: done
+  icon-translations: done
   reconfiguration-flow: todo
   repair-issues:
     status: exempt
@@ -75,4 +69,4 @@ rules:
   # Platinum
   async-dependency: done
   inject-websession: todo
-  strict-typing: todo
+  strict-typing: done

--- a/custom_components/actronair/sensor.py
+++ b/custom_components/actronair/sensor.py
@@ -1,161 +1,215 @@
 """Sensor platform for Actron Air integration."""
 
-from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
-from homeassistant.const import PERCENTAGE, UnitOfPower, UnitOfTemperature
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from collections.abc import Callable
+from dataclasses import dataclass
 
-from .coordinator import ActronAirConfigEntry
-from .entity import (
-    EntitySensor,
-    PeripheralBatterySensor,
-    PeripheralHumiditySensor,
-    PeripheralTemperatureSensor,
-    ZoneHumiditySensor,
-    ZoneTemperatureSensor,
-    DIAGNOSTIC_CATEGORY,
+from actron_neo_api import ActronAirStatus
+from actron_neo_api.models.zone import ActronAirPeripheral
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.const import (
+    PERCENTAGE,
+    EntityCategory,
+    REVOLUTIONS_PER_MINUTE,
+    UnitOfPower,
+    UnitOfTemperature,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import ActronAirConfigEntry, ActronAirSystemCoordinator
+from .entity import ActronAirAcEntity, ActronAirPeripheralEntity
+
+PARALLEL_UPDATES = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class ActronAirSensorEntityDescription(SensorEntityDescription):
+    """Describes Actron Air sensor entity."""
+
+    value_fn: Callable[[ActronAirStatus], str | float | int | None]
+
+
+@dataclass(frozen=True, kw_only=True)
+class ActronAirPeripheralSensorEntityDescription(SensorEntityDescription):
+    """Describes Actron Air peripheral sensor entity."""
+
+    value_fn: Callable[[ActronAirPeripheral], float | None]
+
+
+SENSORS: tuple[ActronAirSensorEntityDescription, ...] = (
+    ActronAirSensorEntityDescription(
+        key="compressor_mode",
+        translation_key="compressor_mode",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda status: status.compressor_mode,
+    ),
+    ActronAirSensorEntityDescription(
+        key="compressor_chasing_temperature",
+        translation_key="compressor_chasing_temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda status: status.compressor_chasing_temperature,
+    ),
+    ActronAirSensorEntityDescription(
+        key="compressor_live_temperature",
+        translation_key="compressor_live_temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda status: status.compressor_live_temperature,
+    ),
+    ActronAirSensorEntityDescription(
+        key="compressor_power",
+        translation_key="compressor_power",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda status: status.compressor_power,
+    ),
+    ActronAirSensorEntityDescription(
+        key="compressor_speed",
+        translation_key="compressor_speed",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda status: status.compressor_speed,
+    ),
+    ActronAirSensorEntityDescription(
+        key="compressor_capacity",
+        translation_key="compressor_capacity",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=PERCENTAGE,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda status: status.live_aircon.compressor_capacity,
+    ),
+    ActronAirSensorEntityDescription(
+        key="fan_rpm",
+        translation_key="fan_rpm",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=REVOLUTIONS_PER_MINUTE,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda status: status.live_aircon.fan_rpm,
+    ),
+    ActronAirSensorEntityDescription(
+        key="outdoor_temperature",
+        translation_key="outdoor_temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        value_fn=lambda status: status.outdoor_temperature,
+    ),
+)
+
+PERIPHERAL_SENSORS: tuple[ActronAirPeripheralSensorEntityDescription, ...] = (
+    ActronAirPeripheralSensorEntityDescription(
+        key="temperature",
+        translation_key="peripheral_temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        value_fn=lambda peripheral: peripheral.temperature,
+    ),
+    ActronAirPeripheralSensorEntityDescription(
+        key="humidity",
+        translation_key="peripheral_humidity",
+        device_class=SensorDeviceClass.HUMIDITY,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=PERCENTAGE,
+        value_fn=lambda peripheral: peripheral.humidity,
+    ),
+    ActronAirPeripheralSensorEntityDescription(
+        key="battery",
+        translation_key="peripheral_battery",
+        device_class=SensorDeviceClass.BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=PERCENTAGE,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda peripheral: peripheral.battery_level,
+    ),
 )
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ActronAirConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up Actron Air entities."""
-
-    # Sensor configurations with appropriate entity categories, device classes, and enabled_default
-    # Format: translation_key, sensor_name, device_class, unit, entity_category, state_class, enabled_default
-    sensor_configs = [
-        (
-            "clean_filter",
-            "clean_filter",
-            SensorDeviceClass.ENUM,
-            None,
-            DIAGNOSTIC_CATEGORY,
-            SensorStateClass.MEASUREMENT,
-            True,
-        ),
-        (
-            "defrost_mode",
-            "defrost_mode",
-            SensorDeviceClass.ENUM,
-            None,
-            DIAGNOSTIC_CATEGORY,
-            SensorStateClass.MEASUREMENT,
-            False,
-        ),
-        (
-            "compressor_chasing_temperature",
-            "compressor_chasing_temperature",
-            SensorDeviceClass.TEMPERATURE,
-            UnitOfTemperature.CELSIUS,
-            DIAGNOSTIC_CATEGORY,
-            SensorStateClass.MEASUREMENT,
-            False,
-        ),
-        (
-            "compressor_live_temperature",
-            "compressor_live_temperature",
-            SensorDeviceClass.TEMPERATURE,
-            UnitOfTemperature.CELSIUS,
-            DIAGNOSTIC_CATEGORY,
-            SensorStateClass.MEASUREMENT,
-            False,
-        ),
-        (
-            "compressor_mode",
-            "compressor_mode",
-            SensorDeviceClass.ENUM,
-            None,
-            DIAGNOSTIC_CATEGORY,
-            None,
-            False,
-        ),
-        (
-            "system_on",
-            "system_on",
-            SensorDeviceClass.ENUM,
-            None,
-            None,
-            None,
-            True,
-        ),
-        (
-            "compressor_speed",
-            "compressor_speed",
-            SensorDeviceClass.SPEED,
-            None,
-            DIAGNOSTIC_CATEGORY,
-            SensorStateClass.MEASUREMENT,
-            False,
-        ),
-        (
-            "compressor_power",
-            "compressor_power",
-            SensorDeviceClass.POWER,
-            UnitOfPower.WATT,
-            DIAGNOSTIC_CATEGORY,
-            SensorStateClass.MEASUREMENT,
-            False,
-        ),
-        (
-            "outdoor_temperature",
-            "outdoor_temperature",
-            SensorDeviceClass.TEMPERATURE,
-            UnitOfTemperature.CELSIUS,
-            None,
-            SensorStateClass.MEASUREMENT,
-            True,
-        ),
-        (
-            "humidity",
-            "humidity",
-            SensorDeviceClass.HUMIDITY,
-            PERCENTAGE,
-            None,
-            SensorStateClass.MEASUREMENT,
-            True,
-        ),
-    ]
-
+    """Set up Actron Air sensor entities."""
     system_coordinators = entry.runtime_data.system_coordinators
-    entities: list[EntitySensor] = []
+    entities: list[SensorEntity] = []
 
     for coordinator in system_coordinators.values():
-        status = coordinator.data
+        entities.extend(
+            ActronAirSensor(coordinator, description)
+            for description in SENSORS
+        )
+        entities.extend(
+            ActronAirPeripheralSensor(coordinator, peripheral, description)
+            for peripheral in coordinator.data.peripherals
+            for description in PERIPHERAL_SENSORS
+        )
 
-        for (
-            translation_key,
-            sensor_name,
-            device_class,
-            unit,
-            entity_category,
-            state_class,
-            enabled_default,
-        ) in sensor_configs:
-            sensor = EntitySensor(
-                coordinator = coordinator,
-                translation_key = translation_key,
-                sensor_name = sensor_name,
-                device_class = device_class,
-                unit_of_measurement = unit,
-                is_diagnostic = False,
-                entity_category = entity_category,
-                state_class = state_class,
-                enabled_default = enabled_default,
-            )
-            entities.append(sensor)
+    async_add_entities(entities)
 
-        for zone in status.remote_zone_info:
-            if zone.exists:
-                entities.append(ZoneTemperatureSensor(coordinator, zone))
-                entities.append(ZoneHumiditySensor(coordinator, zone))
 
-        for peripheral in status.peripherals:
-            entities.append(PeripheralBatterySensor(coordinator, peripheral))
-            entities.append(PeripheralTemperatureSensor(coordinator, peripheral))
-            entities.append(PeripheralHumiditySensor(coordinator, peripheral))
+class ActronAirSensor(ActronAirAcEntity, SensorEntity):
+    """Representation of an Actron Air sensor."""
 
-        # Add all sensors
-        async_add_entities(entities)
+    entity_description: ActronAirSensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: ActronAirSystemCoordinator,
+        description: ActronAirSensorEntityDescription,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.serial_number}_{description.key}"
+
+    @property
+    def native_value(self) -> str | float | int | None:
+        """Return the state of the sensor."""
+        return self.entity_description.value_fn(self.coordinator.data)
+
+
+class ActronAirPeripheralSensor(ActronAirPeripheralEntity, SensorEntity):
+    """Representation of an Actron Air peripheral sensor."""
+
+    entity_description: ActronAirPeripheralSensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: ActronAirSystemCoordinator,
+        peripheral: ActronAirPeripheral,
+        description: ActronAirPeripheralSensorEntityDescription,
+    ) -> None:
+        """Initialize the peripheral sensor."""
+        super().__init__(coordinator, peripheral)
+        self.entity_description = description
+        self._attr_unique_id = (
+            f"{peripheral.serial_number}_{description.key}"
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the state of the sensor."""
+        if (peripheral := self._peripheral) is None:
+            return None
+        return self.entity_description.value_fn(peripheral)

--- a/custom_components/actronair/strings.json
+++ b/custom_components/actronair/strings.json
@@ -19,7 +19,7 @@
         "title": "Connection error"
       },
       "reauth_confirm": {
-        "description": "Please select continue to reauthenticate to your Actron Air account.",
+        "description": "Your Actron Air authentication has expired. Select continue to reauthenticate with your Actron Air account. You will be prompted to log in again to restore the connection.",
         "title": "Authentication expired"
       },
       "timeout": {
@@ -32,9 +32,80 @@
       }
     }
   },
+  "entity": {
+    "binary_sensor": {
+      "clean_filter": {
+        "name": "Clean filter"
+      },
+      "defrost_mode": {
+        "name": "Defrost mode"
+      }
+    },
+    "sensor": {
+      "compressor_mode": {
+        "name": "Compressor mode"
+      },
+      "compressor_chasing_temperature": {
+        "name": "Compressor chasing temperature"
+      },
+      "compressor_live_temperature": {
+        "name": "Compressor live temperature"
+      },
+      "compressor_power": {
+        "name": "Compressor power"
+      },
+      "compressor_speed": {
+        "name": "Compressor speed"
+      },
+      "compressor_capacity": {
+        "name": "Compressor capacity"
+      },
+      "fan_rpm": {
+        "name": "Fan speed"
+      },
+      "outdoor_temperature": {
+        "name": "Outdoor temperature"
+      },
+      "peripheral_temperature": {
+        "name": "Temperature"
+      },
+      "peripheral_humidity": {
+        "name": "Humidity"
+      },
+      "peripheral_battery": {
+        "name": "Battery"
+      }
+    },
+    "switch": {
+      "away_mode": {
+        "name": "Away mode"
+      },
+      "continuous_fan": {
+        "name": "Continuous fan"
+      },
+      "quiet_mode": {
+        "name": "Quiet mode"
+      },
+      "turbo_mode": {
+        "name": "Turbo mode"
+      }
+    }
+  },
   "exceptions": {
+    "api_error": {
+      "message": "Failed to communicate with Actron Air device: {error}"
+    },
     "auth_error": {
       "message": "Authentication failed, please reauthenticate"
+    },
+    "setup_connection_error": {
+      "message": "Failed to connect to the Actron Air API"
+    },
+    "temperature_missing": {
+      "message": "Provide a temperature value when adjusting the climate entity."
+    },
+    "update_error": {
+      "message": "An error occurred while retrieving data from the Actron Air API: {error}"
     }
   }
 }

--- a/custom_components/actronair/switch.py
+++ b/custom_components/actronair/switch.py
@@ -1,192 +1,116 @@
 """Switch platform for Actron Air integration."""
 
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from typing import Any
 
-from homeassistant.components.switch import SwitchEntity, SwitchDeviceClass
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import ActronAirConfigEntry
-from .entity import CONFIG_CATEGORY
+from .coordinator import ActronAirConfigEntry, ActronAirSystemCoordinator
+from .entity import ActronAirAcEntity, actron_air_command
+
+PARALLEL_UPDATES = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class ActronAirSwitchEntityDescription(SwitchEntityDescription):
+    """Class describing Actron Air switch entities."""
+
+    is_on_fn: Callable[[ActronAirSystemCoordinator], bool]
+    set_fn: Callable[[ActronAirSystemCoordinator, bool], Awaitable[None]]
+    is_supported_fn: Callable[[ActronAirSystemCoordinator], bool] = lambda _: True
+
+
+SWITCHES: tuple[ActronAirSwitchEntityDescription, ...] = (
+    ActronAirSwitchEntityDescription(
+        key="away_mode",
+        translation_key="away_mode",
+        is_on_fn=lambda coordinator: coordinator.data.user_aircon_settings.away_mode,
+        set_fn=lambda coordinator, enabled: (
+            coordinator.data.user_aircon_settings.set_away_mode(enabled)
+        ),
+    ),
+    ActronAirSwitchEntityDescription(
+        key="continuous_fan",
+        translation_key="continuous_fan",
+        is_on_fn=lambda coordinator: (
+            coordinator.data.user_aircon_settings.continuous_fan_enabled
+        ),
+        set_fn=lambda coordinator, enabled: (
+            coordinator.data.user_aircon_settings.set_continuous_mode(enabled)
+        ),
+    ),
+    ActronAirSwitchEntityDescription(
+        key="quiet_mode",
+        translation_key="quiet_mode",
+        is_on_fn=lambda coordinator: (
+            coordinator.data.user_aircon_settings.quiet_mode_enabled
+        ),
+        set_fn=lambda coordinator, enabled: (
+            coordinator.data.user_aircon_settings.set_quiet_mode(enabled)
+        ),
+    ),
+    ActronAirSwitchEntityDescription(
+        key="turbo_mode",
+        translation_key="turbo_mode",
+        is_on_fn=lambda coordinator: (
+            coordinator.data.user_aircon_settings.turbo_enabled
+        ),
+        set_fn=lambda coordinator, enabled: (
+            coordinator.data.user_aircon_settings.set_turbo_mode(enabled)
+        ),
+        is_supported_fn=lambda coordinator: (
+            coordinator.data.user_aircon_settings.turbo_supported
+        ),
+    ),
+)
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ActronAirConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up Actron Air switches."""
-    # Extract API and coordinator from hass.data
+    """Set up Actron Air switch entities."""
     system_coordinators = entry.runtime_data.system_coordinators
+    async_add_entities(
+        ActronAirSwitch(coordinator, description)
+        for coordinator in system_coordinators.values()
+        for description in SWITCHES
+        if description.is_supported_fn(coordinator)
+    )
 
-    # Fetch the status and create ZoneSwitches
-    entities: list[SwitchEntity] = []
 
-    for coordinator in system_coordinators.values():
-        entities.append(AwayModeSwitch(coordinator))
-        entities.append(ContinuousFanSwitch(coordinator))
-        entities.append(QuietModeSwitch(coordinator))
+class ActronAirSwitch(ActronAirAcEntity, SwitchEntity):
+    """Actron Air switch."""
 
-        if coordinator.data.user_aircon_settings.turbo_supported:
-            entities.append(TurboModeSwitch(coordinator))
+    _attr_entity_category = EntityCategory.CONFIG
+    entity_description: ActronAirSwitchEntityDescription
 
-    # Add all switches
-    async_add_entities(entities)
-
-class AwayModeSwitch(CoordinatorEntity, SwitchEntity):
-    """Representation of the Actron Air away mode switch."""
-
-    _attr_has_entity_name = True
-    _attr_translation_key = "away_mode"
-    _attr_entity_category = CONFIG_CATEGORY
-    _attr_device_class = SwitchDeviceClass.SWITCH
-    _attr_entity_registry_enabled_default = True
-
-    def __init__(self, coordinator) -> None:
-        """Initialize the away mode switch."""
+    def __init__(
+        self,
+        coordinator: ActronAirSystemCoordinator,
+        description: ActronAirSwitchEntityDescription,
+    ) -> None:
+        """Initialize the switch."""
         super().__init__(coordinator)
-        self._serial_number = coordinator.serial_number
-        self._attr_unique_id: str = f"{self._serial_number}_{self._attr_translation_key}"
-        self._attr_device_info: DeviceInfo = DeviceInfo(
-            identifiers={(DOMAIN, self._serial_number)},
-        )
-        self.on_icon = "mdi:home-export-outline"
-        self.off_icon = "mdi:home-import-outline"
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.serial_number}_{description.key}"
 
     @property
     def is_on(self) -> bool:
         """Return true if the switch is on."""
-        return self.coordinator.data.user_aircon_settings.away_mode
+        return self.entity_description.is_on_fn(self.coordinator)
 
-    @property
-    def icon(self) -> str:
-        """Return the icon based on the state."""
-        return self.on_icon if self.is_on else self.off_icon
-
+    @actron_air_command
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the continuous fan on."""
-        await self.coordinator.data.user_aircon_settings.set_away_mode(True)
+        """Turn the switch on."""
+        await self.entity_description.set_fn(self.coordinator, True)
 
+    @actron_air_command
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the continuous fan off."""
-        await self.coordinator.data.user_aircon_settings.set_away_mode(False)
-
-
-class ContinuousFanSwitch(CoordinatorEntity, SwitchEntity):
-    """Representation of the Actron Air continuous fan switch."""
-
-    _attr_has_entity_name = True
-    _attr_translation_key = "continuous_fan"
-    _attr_entity_category = CONFIG_CATEGORY
-    _attr_device_class = SwitchDeviceClass.SWITCH
-    _attr_entity_registry_enabled_default = True
-
-    def __init__(self, coordinator) -> None:
-        """Initialize the away mode switch."""
-        super().__init__(coordinator)
-        self._serial_number = coordinator.serial_number
-        self._attr_unique_id: str = f"{self._serial_number}_{self._attr_translation_key}"
-        self._attr_device_info: DeviceInfo = DeviceInfo(
-            identifiers={(DOMAIN, self._serial_number)},
-        )
-        self.on_icon = "mdi:fan"
-        self.off_icon = "mdi:fan-off"
-
-    @property
-    def is_on(self) -> bool:
-        """Return true if the switch is on."""
-        return self.coordinator.data.user_aircon_settings.continuous_fan_enabled
-
-    @property
-    def icon(self) -> str:
-        """Return the icon based on the state."""
-        return self.on_icon if self.is_on else self.off_icon
-
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the continuous fan on."""
-        await self.coordinator.data.user_aircon_settings.set_continuous_mode(True)
-
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the continuous fan off."""
-        await self.coordinator.data.user_aircon_settings.set_continuous_mode(False)
-
-
-class QuietModeSwitch(CoordinatorEntity, SwitchEntity):
-    """Representation of the Actron Air quiet mode switch."""
-
-    _attr_has_entity_name = True
-    _attr_translation_key = "quiet_mode"
-    _attr_entity_category = CONFIG_CATEGORY
-    _attr_device_class = SwitchDeviceClass.SWITCH
-    _attr_entity_registry_enabled_default = True
-
-    def __init__(self, coordinator) -> None:
-        """Initialize the away mode switch."""
-        super().__init__(coordinator)
-        self._serial_number = coordinator.serial_number
-        self._attr_unique_id: str = f"{self._serial_number}_{self._attr_translation_key}"
-        self._attr_device_info: DeviceInfo = DeviceInfo(
-            identifiers={(DOMAIN, self._serial_number)},
-        )
-        self.on_icon = "mdi:volume-low"
-        self.off_icon = "mdi:volume-high"
-
-    @property
-    def is_on(self) -> bool:
-        """Return true if the switch is on."""
-        return self.coordinator.data.user_aircon_settings.quiet_mode_enabled
-
-    @property
-    def icon(self) -> str:
-        """Return the icon based on the state."""
-        return self.on_icon if self.is_on else self.off_icon
-
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the quiet mode setting on."""
-        await self.coordinator.data.user_aircon_settings.set_quiet_mode(True)
-
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the quiet mode setting off."""
-        await self.coordinator.data.user_aircon_settings.set_quiet_mode(False)
-
-
-class TurboModeSwitch(CoordinatorEntity, SwitchEntity):
-    """Representation of the Actron Air turbo mode switch."""
-
-    _attr_has_entity_name = True
-    _attr_translation_key = "turbo_mode"
-    _attr_entity_category = CONFIG_CATEGORY
-    _attr_device_class = SwitchDeviceClass.SWITCH
-    _attr_entity_registry_enabled_default = True
-
-    def __init__(self, coordinator) -> None:
-        """Initialize the away mode switch."""
-        super().__init__(coordinator)
-        self._serial_number = coordinator.serial_number
-        self._attr_unique_id: str = f"{self._serial_number}_{self._attr_translation_key}"
-        self._attr_device_info: DeviceInfo = DeviceInfo(
-            identifiers={(DOMAIN, self._serial_number)},
-        )
-        self.on_icon = "mdi:fan-plus"
-        self.off_icon = "mdi:fan"
-
-    @property
-    def is_on(self) -> bool:
-        """Return true if the switch is on."""
-        return self.coordinator.data.user_aircon_settings.turbo_enabled
-
-    @property
-    def icon(self) -> str:
-        """Return the icon based on the state."""
-        return self.on_icon if self.is_on else self.off_icon
-
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the turbo mode on."""
-        await self.coordinator.data.user_aircon_settings.set_turbo_mode(True)
-
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the turbo mode off."""
-        await self.coordinator.data.user_aircon_settings.set_turbo_mode(False)
+        """Turn the switch off."""
+        await self.entity_description.set_fn(self.coordinator, False)

--- a/custom_components/actronair/translations/en.json
+++ b/custom_components/actronair/translations/en.json
@@ -31,6 +31,17 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "clean_filter": {
+        "name": "Clean Filter"
+      },
+      "defrost_mode": {
+        "name": "Defrost Mode"
+      },
+      "compressor_mode": {
+        "name": "Compressor Mode"
+      }
+    },
     "cover": {
       "zone_position": {
         "name": "Zone Position"
@@ -68,6 +79,12 @@
       },
       "compressor_power": {
         "name": "Compressor Power"
+      },
+      "compressor_capacity": {
+        "name": "Compressor Capacity"
+      },
+      "fan_rpm": {
+        "name": "Fan Speed"
       },
       "outdoor_temperature": {
         "name": "Outdoor Temperature"

--- a/custom_components/actronair/translations/icons.json
+++ b/custom_components/actronair/translations/icons.json
@@ -1,93 +1,28 @@
 {
   "entity": {
-    "climate": {
-      "ac_unit": {
-        "default": "mdi:hvac",
-        "state": {
-          "auto": "mdi:hvac",
-          "cool": "mdi:snowflake",
-          "dry": "mdi:water-percent",
-          "fan_only": "mdi:fan",
-          "heat": "mdi:fire",
-          "off": "mdi:hvac-off"
-        },
-        "state_attributes": {
-          "hvac_action": {
-            "cooling": "mdi:snowflake",
-            "heating": "mdi:fire",
-            "idle": "mdi:fan-off",
-            "off": "mdi:power-off"
-          }
-        }
-      },
-      "ac_zone": {
-        "default": "mdi:hvac",
-        "state": {
-          "auto": "mdi:hvac",
-          "cool": "mdi:snowflake",
-          "dry": "mdi:water-percent",
-          "fan_only": "mdi:fan",
-          "heat": "mdi:fire",
-          "off": "mdi:hvac-off"
-        },
-        "state_attributes": {
-          "hvac_action": {
-            "cooling": "mdi:snowflake",
-            "heating": "mdi:fire",
-            "idle": "mdi:fan-off",
-            "off": "mdi:power-off"
-          }
-        }
-      }
-    },
-    "sensor": {
-      "clean_filter": {
-        "default": "mdi:air-filter"
-      },
-      "defrost_mode": {
-        "default": "mdi:snowflake-melt"
-      },
-      "compressor_mode": {
-        "default": "mdi:compressor"
-      },
-      "system_on": {
-        "default": "mdi:power",
-        "state": {
-          "on": "mdi:power",
-          "off": "mdi:power-off"
-        }
-      },
-      "position": {
-        "default": "mdi:adjust"
-      }
-    },
     "switch": {
       "away_mode": {
-        "default": "mdi:home-outline",
+        "default": "mdi:home-export-outline",
         "state": {
-          "on": "mdi:home-export-outline",
-          "off": "mdi:home-outline"
+          "off": "mdi:home-import-outline"
         }
       },
       "continuous_fan": {
         "default": "mdi:fan",
         "state": {
-          "on": "mdi:fan",
           "off": "mdi:fan-off"
         }
       },
       "quiet_mode": {
-        "default": "mdi:volume-medium",
+        "default": "mdi:volume-low",
         "state": {
-          "on": "mdi:volume-low",
           "off": "mdi:volume-high"
         }
       },
       "turbo_mode": {
-        "default": "mdi:speedometer-medium",
+        "default": "mdi:fan-plus",
         "state": {
-          "on": "mdi:speedometer",
-          "off": "mdi:speedometer-slow"
+          "off": "mdi:fan"
         }
       }
     }

--- a/custom_components/actronair/translations/strings.json
+++ b/custom_components/actronair/translations/strings.json
@@ -1,125 +1,102 @@
 {
   "config": {
-    "step": {
-      "user": {
-        "title": "Actron Air OAuth2 Authorization"
-      },
-      "timeout": {
-        "title": "Authorization timeout",
-        "description": "The authorization process timed out. Please try again.",
-        "data": {}
-      }
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "oauth2_error": "Failed to start authentication flow",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "wrong_account": "You must reauthenticate with the same Actron Air account that was originally configured."
+    },
+    "error": {
+      "oauth2_error": "Failed to start authentication flow. Please try again later."
     },
     "progress": {
       "wait_for_authorization": "To authenticate, open the following URL and login at Actron Air:\n{verification_uri}\nIf the code is not automatically copied, paste the following code to authorize the integration:\n\n```{user_code}```\n\n\nThe login attempt will time out after {expires_minutes} minutes."
     },
-    "error": {
-      "oauth2_error": "Failed to start OAuth2 flow. Please try again later."
-    },
-    "abort": {
-      "oauth2_error": "Failed to start OAuth2 flow",
-      "already_configured": "Account is already configured"
-    }
-  },
-  "device_automation": {
-    "action_type": {
-      "turn_on": "Turn on Actron Air device",
-      "turn_off": "Turn off Actron Air device"
-    }
-  },
-  "options": {
     "step": {
-      "init": {
-        "data": {
-          "reconfigure": "Reconfigure account credentials"
-        },
-        "description": "Configure options for the Actron Air integration.",
-        "title": "Actron Air Options"
+      "connection_error": {
+        "data": {},
+        "description": "Failed to connect to Actron Air. Please check your internet connection and try again.",
+        "title": "Connection error"
       },
-      "reconfigure": {
-        "data": {
-          "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]"
-        },
-        "description": "Update your Actron Air account credentials.",
-        "title": "Reconfigure Actron Air Account"
+      "reauth_confirm": {
+        "description": "Your Actron Air authentication has expired. Select continue to reauthenticate with your Actron Air account. You will be prompted to log in again to restore the connection.",
+        "title": "Authentication expired"
+      },
+      "timeout": {
+        "data": {},
+        "description": "The authentication process timed out. Please try again.",
+        "title": "Authentication timeout"
+      },
+      "user": {
+        "title": "Actron Air Authentication"
       }
     }
   },
   "entity": {
-    "climate": {
-      "ac_unit": {
-        "name": "AC Unit {serial_number}"
+    "binary_sensor": {
+      "clean_filter": {
+        "name": "Clean filter"
       },
-      "ac_zone": {
-        "name": "AC Zone"
+      "defrost_mode": {
+        "name": "Defrost mode"
       }
     },
     "sensor": {
-      "clean_filter": {
-        "name": "Clean Filter"
-      },
-      "defrost_mode": {
-        "name": "Defrost Mode"
+      "compressor_mode": {
+        "name": "Compressor mode"
       },
       "compressor_chasing_temperature": {
-        "name": "Compressor Chasing Temperature"
+        "name": "Compressor chasing temperature"
       },
       "compressor_live_temperature": {
-        "name": "Compressor Live Temperature"
-      },
-      "compressor_mode": {
-        "name": "Compressor Mode"
-      },
-      "system_on": {
-        "name": "System On"
-      },
-      "compressor_speed": {
-        "name": "Compressor Speed"
+        "name": "Compressor live temperature"
       },
       "compressor_power": {
-        "name": "Compressor Power"
+        "name": "Compressor power"
+      },
+      "compressor_speed": {
+        "name": "Compressor speed"
+      },
+      "compressor_capacity": {
+        "name": "Compressor capacity"
+      },
+      "fan_rpm": {
+        "name": "Fan speed"
       },
       "outdoor_temperature": {
-        "name": "Outdoor Temperature"
-      },
-      "humidity": {
-        "name": "Humidity"
-      },
-      "temperature": {
-        "name": "Temperature"
-      },
-      "position": {
-        "name": "Position"
-      },
-      "battery": {
-        "name": "Battery"
+        "name": "Outdoor temperature"
       }
     },
     "switch": {
       "away_mode": {
-        "name": "Away Mode"
+        "name": "Away mode"
       },
       "continuous_fan": {
-        "name": "Continuous Fan"
+        "name": "Continuous fan"
       },
       "quiet_mode": {
-        "name": "Quiet Mode"
+        "name": "Quiet mode"
       },
       "turbo_mode": {
-        "name": "Turbo Mode"
+        "name": "Turbo mode"
       }
     }
   },
-  "issues": {
-    "stale_auth": {
-      "title": "Actron Air authentication expired",
-      "description": "The authentication for your {name} Actron Air account has expired. This can happen if you changed your password or the token has expired.\n\nPlease click the 'Fix' button below to re-authenticate with your Actron Air account."
+  "exceptions": {
+    "api_error": {
+      "message": "Failed to communicate with Actron Air device: {error}"
     },
-    "confirm": {
-      "title": "Confirm repair",
-      "description": "Do you want to apply this repair?"
+    "auth_error": {
+      "message": "Authentication failed, please reauthenticate"
+    },
+    "setup_connection_error": {
+      "message": "Failed to connect to the Actron Air API"
+    },
+    "temperature_missing": {
+      "message": "Provide a temperature value when adjusting the climate entity."
+    },
+    "update_error": {
+      "message": "An error occurred while retrieving data from the Actron Air API: {error}"
     }
-  },
-  "title": "Actron Air"
+  }
 }


### PR DESCRIPTION
## Summary

Major refactor of the entity layer to adopt Home Assistant's `EntityDescription` pattern and extract shared base entity classes. Includes an automatic entity migration to preserve existing installations.

## Changes

### Architecture
- **EntityDescription pattern**: Sensors, switches, and binary sensors now use frozen dataclass descriptors instead of ad-hoc per-class implementations
- **Base entity classes**: `ActronAirAcEntity`, `ActronAirZoneEntity`, `ActronAirPeripheralEntity` provide shared device info, availability, and serial number handling
- **`actron_air_command` decorator**: Wraps all API-mutating calls with `ActronAirAPIError` → `HomeAssistantError` translation and automatic coordinator refresh
- **`PARALLEL_UPDATES = 0`** added to all platforms for proper concurrency control

### New features
- **`binary_sensor` platform** — `clean_filter` and `defrost_mode` moved here (was incorrectly typed as `SensorDeviceClass.ENUM`)
- **New sensors**: `compressor_capacity`, `fan_rpm`
- **DRY HVAC mode** support added
- **Dynamic `hvac_modes`** based on device-reported `supported_modes`

### Error handling
- `ConfigEntryNotReady` for API errors during setup (enables automatic retry)
- `UpdateFailed` for coordinator refresh errors
- `ServiceValidationError` for missing temperature in set_temperature calls
- Translatable exception strings in `strings.json`

### API
- Bumped `actron-neo-api` from 0.4.1 → 0.5.5
- Adapted to new Pydantic-based models (`ActronAirSystemInfo`, attribute access instead of dict access)

### Entity migration (`__init__.py`)
Automatic migration runs on setup to preserve existing entities:

| Entity type | Old unique_id | New unique_id |
|---|---|---|
| Main sensors | `compressor_mode` (bare key) | `{serial}_compressor_mode` |
| Cover | `{serial}_zone_{id}_position` | `{serial}_zone_{id}_zone_position` |
| Peripheral sensors | `{periph_serial}_battery` | `{periph_serial}_peripheral_battery` |
| clean_filter / defrost_mode | Removed from sensor platform | Recreated as binary_sensor |

## ⚠️ Breaking changes — removed entities

The following sensors have been **removed** with no direct replacement. Users should migrate automations/dashboards to use the **climate entity** instead:

| Removed sensor | Replacement |
|---|---|
| `sensor.<name>_system_on` | Climate entity HVAC state (`climate.<name>` → `state` attribute) |
| `sensor.<name>_humidity` | Zone climate entity `current_humidity` attribute, or peripheral humidity sensors |
| `sensor.<name>_zone_*_temperature` | Zone climate entity `current_temperature` attribute |
| `sensor.<name>_zone_*_humidity` | Zone climate entity `current_humidity` attribute |

These were redundant with data already exposed by the climate entities and were removed to reduce entity clutter.