### PR TITLE
Bump version to 0.10.9

### DIFF
--- a/custom_components/actronair/manifest.json
+++ b/custom_components/actronair/manifest.json
@@ -18,5 +18,5 @@
   "requirements": [
     "actron-neo-api==0.5.5"
   ],
-  "version": "0.10.8"
+  "version": "0.10.9"
 }


### PR DESCRIPTION
Bumps the integration version from 0.10.8 to 0.10.9 in `manifest.json`.