### PR TITLE
Fix temperature setpoints to be mode aware

### DIFF
--- a/custom_components/actronair/climate.py
+++ b/custom_components/actronair/climate.py
@@ -147,7 +147,7 @@ class ActronSystemClimate(ActronAirAcEntity, ActronAirClimateEntity):
     @property
     def target_temperature(self) -> float:
         """Return the target temperature."""
-        return self._status.user_aircon_settings.temperature_setpoint_cool_c
+        return self._status.user_aircon_settings.current_setpoint
 
     @actron_air_command
     async def async_set_fan_mode(self, fan_mode: str) -> None:
@@ -233,7 +233,7 @@ class ActronZoneClimate(ActronAirZoneEntity, ActronAirClimateEntity):
     @property
     def target_temperature(self) -> float | None:
         """Return the target temperature."""
-        return self._zone.temperature_setpoint_cool_c
+        return self._zone.current_setpoint
 
     @actron_air_command
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:

--- a/custom_components/actronair/manifest.json
+++ b/custom_components/actronair/manifest.json
@@ -16,7 +16,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/kclif9/hassactronneo/issues",
   "requirements": [
-    "actron-neo-api==0.5.5"
+    "actron-neo-api==0.5.6"
   ],
   "version": "0.10.9"
 }


### PR DESCRIPTION
## Summary

Fix temperature setpoints to correctly reflect the active HVAC mode. Actron splits the setpoint between HEAT and all other modes (COOL setpoint), so using the hardcoded `temperature_setpoint_cool_c` returned the wrong target temperature when in HEAT mode.

## Changes

- **climate.py**: Use `current_setpoint` instead of `temperature_setpoint_cool_c` for both the system and zone climate entities, so the target temperature is mode-aware.
- **manifest.json**: Bump `actron-neo-api` from `0.5.5` to `0.5.6` which exposes the `current_setpoint` property.